### PR TITLE
Fix link to deployed website (HTTPS doesn't work, use HTTP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Trinkwasser Visualisierung: Härtegrad, Bestandteile und Kosten
 * Im Verzeichnis converter/ befinden sich die Rohdaten + kleine Skripte, die diese Rohdaten für die Webansicht aufbereiten
 * Im Verzeichnis src/ befinden sich die HTML, CSS und JavaScript Dateien + die aufbereiteten Daten für die Visualisierung. Nach Änderungen einfach grunt gh-pages ausführen, um die Online-Version zu aktualisieren.
 
-Online-Version Potsdam: https://trinkwasser.oklab-potsdam.de
+Online-Version Potsdam: http://trinkwasser.oklab-potsdam.de
 
 Datenquellen:
 ==================


### PR DESCRIPTION
Leider funktioniert https hier nicht https://trinkwasser.oklab-potsdam.de/ und lässt sich wahrscheinlich ohne weiteres auch nicht reparieren